### PR TITLE
Properly update attachments on neighbor change

### DIFF
--- a/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
+++ b/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
@@ -260,6 +260,12 @@ public class BlockDuct extends BlockTDBase implements IBlockAppearance, IConfigG
 	}
 
 	@Override
+	public boolean getWeakChanges(IBlockAccess world, BlockPos pos) {
+
+		return true;
+	}
+
+	@Override
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
 
 		float min = getSize(state);

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
@@ -14,10 +14,7 @@ import cofh.core.util.helpers.BlockHelper;
 import cofh.core.util.helpers.ServerHelper;
 import cofh.thermaldynamics.ThermalDynamics;
 import cofh.thermaldynamics.block.BlockDuct;
-import cofh.thermaldynamics.duct.Attachment;
-import cofh.thermaldynamics.duct.AttachmentRegistry;
-import cofh.thermaldynamics.duct.DuctUnitStructural;
-import cofh.thermaldynamics.duct.GridStructural;
+import cofh.thermaldynamics.duct.*;
 import cofh.thermaldynamics.duct.attachments.cover.CoverHoleRender;
 import cofh.thermaldynamics.duct.attachments.cover.CoverHoleRender.CoverTransformer;
 import cofh.thermaldynamics.duct.tiles.DuctToken;
@@ -194,7 +191,7 @@ public class Relay extends Attachment implements IConfigGui, IPortableData {
 			if (isBlockDuct(block)) {
 				TileGrid t = (TileGrid) baseTile.world().getTileEntity(offsetPos);
 				Attachment attachment = t.getAttachment(this.side ^ 1);
-				if (attachment != null && !(attachment instanceof Relay)) {
+				if (attachment != null && !(attachment instanceof Relay && (t.getDuctType() == TDDucts.structure || t.getDuctType() == baseTile.getDuctType()))) {
 					level = attachment.getRSOutput();
 				}
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
@@ -194,7 +194,7 @@ public class Relay extends Attachment implements IConfigGui, IPortableData {
 			if (isBlockDuct(block)) {
 				TileGrid t = (TileGrid) baseTile.world().getTileEntity(offsetPos);
 				Attachment attachment = t.getAttachment(this.side ^ 1);
-				if (attachment != null) {
+				if (attachment != null && !(attachment instanceof Relay)) {
 					level = attachment.getRSOutput();
 				}
 

--- a/src/main/java/cofh/thermaldynamics/duct/tiles/TileGrid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/tiles/TileGrid.java
@@ -52,10 +52,7 @@ import org.apache.commons.lang3.Validate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import static cofh.thermaldynamics.duct.ConnectionType.*;
 
@@ -242,22 +239,21 @@ public abstract class TileGrid extends TileCore implements IDuctHolder, IPortabl
 			int dz = pos.getZ() - neighbor.getZ();
 			if (dz == 0) {
 				int dy = pos.getY() - neighbor.getY();
-				if (dy == 1) {
-					return EnumFacing.UP;
-				} else if (dy == -1) {
+				if (dy >= 1) {
 					return EnumFacing.DOWN;
+				} else {
+					return EnumFacing.UP;
 				}
-			} else if (dz == 1) {
-				return EnumFacing.SOUTH;
-			} else if (dz == -1) {
+			} else if (dz >= 1) {
 				return EnumFacing.NORTH;
+			} else {
+				return EnumFacing.SOUTH;
 			}
-		} else if (dx == 1) {
-			return EnumFacing.EAST;
-		} else if (dx == -1) {
+		} else if (dx >= 1) {
 			return EnumFacing.WEST;
+		} else {
+			return EnumFacing.EAST;
 		}
-		throw new IllegalStateException("Positions " + pos + " and " + neighbor + " are not adjacent");
 	}
 
 	private int getTileHash() {


### PR DESCRIPTION
Fixes CoFH/Feedback#840.
Also allows the relays to work through blocks like vanilla comparators.
This PR also prevents the looping issue mentioned in CoFH/Feedback#801