### PR TITLE
[1.12] Allow addons to create custom attachments

### DIFF
--- a/src/main/java/cofh/thermaldynamics/duct/Attachment.java
+++ b/src/main/java/cofh/thermaldynamics/duct/Attachment.java
@@ -18,6 +18,7 @@ import net.minecraft.inventory.IContainerListener;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.ITextComponent;
@@ -41,7 +42,7 @@ public abstract class Attachment {
 
 	public abstract String getName();
 
-	public abstract int getId();
+	public abstract ResourceLocation getId();
 
 	public abstract boolean isNode();
 

--- a/src/main/java/cofh/thermaldynamics/duct/AttachmentRegistry.java
+++ b/src/main/java/cofh/thermaldynamics/duct/AttachmentRegistry.java
@@ -1,5 +1,6 @@
 package cofh.thermaldynamics.duct;
 
+import cofh.thermaldynamics.ThermalDynamics;
 import cofh.thermaldynamics.duct.attachments.cover.Cover;
 import cofh.thermaldynamics.duct.attachments.filter.FilterFluid;
 import cofh.thermaldynamics.duct.attachments.filter.FilterItem;
@@ -9,38 +10,51 @@ import cofh.thermaldynamics.duct.attachments.retriever.RetrieverItem;
 import cofh.thermaldynamics.duct.attachments.servo.ServoFluid;
 import cofh.thermaldynamics.duct.attachments.servo.ServoItem;
 import cofh.thermaldynamics.duct.tiles.TileGrid;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class AttachmentRegistry {
 
-	public final static byte FACADE = 0;
-	public final static byte SERVO_FLUID = 1;
-	public final static byte SERVO_ITEM = 2;
-	public final static byte FILTER_FLUID = 3;
-	public final static byte FILTER_ITEM = 4;
-	public final static byte RETRIEVER_FLUID = 5;
-	public final static byte RETRIEVER_ITEM = 6;
-	public final static byte RELAY = 7;
+	private final static Map<ResourceLocation, BiFunction<TileGrid, Byte, Attachment>> REGISTRY = new HashMap<>();
 
-	public static Attachment createAttachment(TileGrid tile, byte side, int id) {
+	public final static ResourceLocation FACADE = new ResourceLocation(ThermalDynamics.MOD_ID, "facade");
+	public final static ResourceLocation SERVO_FLUID = new ResourceLocation(ThermalDynamics.MOD_ID, "servo_fluid");
+	public final static ResourceLocation SERVO_ITEM = new ResourceLocation(ThermalDynamics.MOD_ID, "servo_item");
+	public final static ResourceLocation FILTER_FLUID = new ResourceLocation(ThermalDynamics.MOD_ID, "filter_fluid");
+	public final static ResourceLocation FILTER_ITEM = new ResourceLocation(ThermalDynamics.MOD_ID, "filter_item");
+	public final static ResourceLocation RETRIEVER_FLUID = new ResourceLocation(ThermalDynamics.MOD_ID, "retriever_fluid");
+	public final static ResourceLocation RETRIEVER_ITEM = new ResourceLocation(ThermalDynamics.MOD_ID, "retriever_item");
+	public final static ResourceLocation RELAY = new ResourceLocation(ThermalDynamics.MOD_ID, "relay");
 
-		if (id == FACADE) {
-			return new Cover(tile, side);
-		} else if (id == SERVO_FLUID) {
-			return new ServoFluid(tile, side);
-		} else if (id == SERVO_ITEM) {
-			return new ServoItem(tile, side);
-		} else if (id == FILTER_FLUID) {
-			return new FilterFluid(tile, side);
-		} else if (id == FILTER_ITEM) {
-			return new FilterItem(tile, side);
-		} else if (id == RETRIEVER_FLUID) {
-			return new RetrieverFluid(tile, side);
-		} else if (id == RETRIEVER_ITEM) {
-			return new RetrieverItem(tile, side);
-		} else if (id == RELAY) {
-			return new Relay(tile, side);
-		}
+	static {
+
+		registerAttachment(FACADE, Cover::new);
+		registerAttachment(SERVO_FLUID, ServoFluid::new);
+		registerAttachment(SERVO_ITEM, ServoItem::new);
+		registerAttachment(FILTER_FLUID, FilterFluid::new);
+		registerAttachment(FILTER_ITEM, FilterItem::new);
+		registerAttachment(RETRIEVER_FLUID, RetrieverFluid::new);
+		registerAttachment(RETRIEVER_ITEM, RetrieverItem::new);
+		registerAttachment(RELAY, Relay::new);
+	}
+
+	public static Attachment createAttachment(TileGrid tile, byte side, ResourceLocation id) {
+
+		if (REGISTRY.containsKey(id))
+			return REGISTRY.get(id).apply(tile, side);
 		throw new RuntimeException("Illegal Attachment ID");
+	}
+
+	public static boolean registerAttachment(ResourceLocation id, BiFunction<TileGrid, Byte, Attachment> function) {
+
+		if (!REGISTRY.containsKey(id)) {
+			REGISTRY.put(id, function);
+			return true;
+		}
+		return false;
 	}
 
 }

--- a/src/main/java/cofh/thermaldynamics/duct/DuctUnitStructural.java
+++ b/src/main/java/cofh/thermaldynamics/duct/DuctUnitStructural.java
@@ -90,7 +90,7 @@ public class DuctUnitStructural extends DuctUnit<DuctUnitStructural, GridStructu
 		if (parent.attachmentData != null && grid != null) {
 			for (Attachment attachment : parent.attachmentData.attachments) {
 				if (attachment != null) {
-					if (attachment.getId() == AttachmentRegistry.RELAY) {
+					if (attachment.getId().equals(AttachmentRegistry.RELAY)) {
 						Relay signaller = (Relay) attachment;
 						if (signaller.isInput()) {
 							grid.addSignalInput(signaller);

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/ConnectionBase.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/ConnectionBase.java
@@ -67,6 +67,29 @@ public abstract class ConnectionBase extends Attachment implements IStuffable, I
 
 	public abstract FilterLogic createFilterLogic();
 
+	/**
+	 * Enables maximum stack size and item routing in the gui
+	 */
+	public abstract boolean isServo();
+
+	/**
+	 * Enables over-sending in the gui
+	 */
+	public abstract boolean isFilter();
+
+	/**
+	 * Whether or not retrievers can pull from the attached inventory
+	 */
+	public abstract boolean canSend();
+
+	/**
+	 * Adds an info tab in the gui
+	 */
+	@SideOnly(Side.CLIENT)
+	public String getInfo() {
+		return null;
+	}
+
 	@Override
 	public boolean isNode() {
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/cover/Cover.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/cover/Cover.java
@@ -20,6 +20,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
@@ -66,7 +67,7 @@ public class Cover extends Attachment {
 	}
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.FACADE;
 	}

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterBase.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterBase.java
@@ -31,6 +31,21 @@ public abstract class FilterBase extends ConnectionBase {
 	}
 
 	@Override
+	public boolean isFilter() {
+		return true;
+	}
+
+	@Override
+	public boolean isServo() {
+		return false;
+	}
+
+	@Override
+	public boolean canSend() {
+		return true;
+	}
+
+	@Override
 	public String getName() {
 
 		return "item.thermaldynamics.filter." + type + ".name";

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterFluid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterFluid.java
@@ -5,6 +5,7 @@ import cofh.thermaldynamics.duct.Duct;
 import cofh.thermaldynamics.duct.tiles.TileGrid;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
@@ -41,7 +42,7 @@ public class FilterFluid extends FilterBase {
 	}
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.FILTER_FLUID;
 	}

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterItem.java
@@ -21,6 +21,11 @@ public class FilterItem extends FilterBase {
 		super(tile, side);
 	}
 
+	@Override
+	public String getInfo() {
+		return "tab.thermaldynamics.filterItem";
+	}
+
 	IItemHandler inventory;
 
 	@Override

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterItem.java
@@ -5,6 +5,7 @@ import cofh.thermaldynamics.duct.Duct;
 import cofh.thermaldynamics.duct.tiles.TileGrid;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
@@ -41,7 +42,7 @@ public class FilterItem extends FilterBase {
 	}
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.FILTER_ITEM;
 	}

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterLogic.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/filter/FilterLogic.java
@@ -421,7 +421,7 @@ public class FilterLogic implements IFilterItems, IFilterFluid, IFilterConfig {
 
 		public boolean appliesTo(FilterLogic base) {
 
-			return base.transferType == ductType && (base.connection.getId() != AttachmentRegistry.FILTER_FLUID || filter) && (base.connection.getId() != AttachmentRegistry.FILTER_ITEM || filter) && (base.connection.getId() != AttachmentRegistry.SERVO_ITEM || servo) && (base.connection.getId() != AttachmentRegistry.SERVO_FLUID || servo) && (base.connection.getId() != AttachmentRegistry.RETRIEVER_ITEM || servo) && (base.connection.getId() != AttachmentRegistry.RETRIEVER_FLUID || servo);
+			return base.transferType == ductType && ((base.connection.isFilter() && filter) || (base.connection.isServo() && servo));
 		}
 	}
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
@@ -42,6 +42,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -93,7 +94,7 @@ public class Relay extends Attachment implements IConfigGui, IPortableData {
 	}
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.RELAY;
 	}

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
@@ -72,7 +72,7 @@ public class RetrieverFluid extends ServoFluid {
 				}
 
 				Attachment attachment = fluidDuct.parent.getAttachment(side);
-				if (attachment != null && attachment.getId() == this.getId()) {
+				if (attachment != null && attachment.getId().equals(this.getId())) {
 					continue;
 				}
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
@@ -6,6 +6,7 @@ import codechicken.lib.vec.Vector3;
 import codechicken.lib.vec.uv.IconTransformation;
 import cofh.thermaldynamics.duct.Attachment;
 import cofh.thermaldynamics.duct.AttachmentRegistry;
+import cofh.thermaldynamics.duct.attachments.ConnectionBase;
 import cofh.thermaldynamics.duct.attachments.servo.ServoFluid;
 import cofh.thermaldynamics.duct.fluid.DuctUnitFluid;
 import cofh.thermaldynamics.duct.fluid.FluidTankGrid;
@@ -35,6 +36,11 @@ public class RetrieverFluid extends ServoFluid {
 	public RetrieverFluid(TileGrid tile, byte side, int type) {
 
 		super(tile, side, type);
+	}
+
+	@Override
+	public boolean canSend() {
+		return false;
 	}
 
 	@Override
@@ -72,7 +78,7 @@ public class RetrieverFluid extends ServoFluid {
 				}
 
 				Attachment attachment = fluidDuct.parent.getAttachment(side);
-				if (attachment != null && attachment.getId().equals(this.getId())) {
+				if (attachment != null && attachment instanceof ConnectionBase && !((ConnectionBase) attachment).canSend()) {
 					continue;
 				}
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -37,7 +38,7 @@ public class RetrieverFluid extends ServoFluid {
 	}
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.RETRIEVER_FLUID;
 	}

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverItem.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -41,7 +42,7 @@ public class RetrieverItem extends ServoItem {
 	}
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.RETRIEVER_ITEM;
 	}
@@ -82,7 +83,7 @@ public class RetrieverItem extends ServoItem {
 
 		baseTileHasOtherOutputs = false;
 		for (int i = 0; i < 6; i++) {
-			if ((itemDuct.isOutput(side) || itemDuct.isInput(side)) && (baseTile.getAttachment(side) == null || baseTile.getAttachment(side).getId() != AttachmentRegistry.RETRIEVER_ITEM)) {
+			if ((itemDuct.isOutput(side) || itemDuct.isInput(side)) && (baseTile.getAttachment(side) == null || !baseTile.getAttachment(side).getId().equals(AttachmentRegistry.RETRIEVER_ITEM))) {
 				baseTileHasOtherOutputs = true;
 				break;
 			}
@@ -102,7 +103,7 @@ public class RetrieverItem extends ServoItem {
 			int i = route.getLastSide();
 
 			Attachment attachment = endPoint.parent.getAttachment(i);
-			if (attachment != null && attachment.getId() == AttachmentRegistry.RETRIEVER_ITEM) {
+			if (attachment != null && attachment.getId().equals(AttachmentRegistry.RETRIEVER_ITEM)) {
 				continue;
 			}
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverItem.java
@@ -7,6 +7,7 @@ import codechicken.lib.vec.uv.IconTransformation;
 import cofh.core.util.helpers.ItemHelper;
 import cofh.thermaldynamics.duct.Attachment;
 import cofh.thermaldynamics.duct.AttachmentRegistry;
+import cofh.thermaldynamics.duct.attachments.ConnectionBase;
 import cofh.thermaldynamics.duct.attachments.servo.ServoItem;
 import cofh.thermaldynamics.duct.item.DuctUnitItem;
 import cofh.thermaldynamics.duct.item.TravelingItem;
@@ -39,6 +40,16 @@ public class RetrieverItem extends ServoItem {
 	public RetrieverItem(TileGrid tile, byte side, int type) {
 
 		super(tile, side, type);
+	}
+
+	@Override
+	public boolean canSend() {
+		return false;
+	}
+
+	@Override
+	public String getInfo() {
+		return "tab.thermaldynamics.retrieverItem";
 	}
 
 	@Override
@@ -83,7 +94,8 @@ public class RetrieverItem extends ServoItem {
 
 		baseTileHasOtherOutputs = false;
 		for (int i = 0; i < 6; i++) {
-			if ((itemDuct.isOutput(side) || itemDuct.isInput(side)) && (baseTile.getAttachment(side) == null || !baseTile.getAttachment(side).getId().equals(AttachmentRegistry.RETRIEVER_ITEM))) {
+			Attachment attachment = baseTile.getAttachment(side);
+			if ((itemDuct.isOutput(side) || itemDuct.isInput(side)) && (attachment == null || !(attachment instanceof  ConnectionBase) || ((ConnectionBase) attachment).canSend())) {
 				baseTileHasOtherOutputs = true;
 				break;
 			}
@@ -103,7 +115,7 @@ public class RetrieverItem extends ServoItem {
 			int i = route.getLastSide();
 
 			Attachment attachment = endPoint.parent.getAttachment(i);
-			if (attachment != null && attachment.getId().equals(AttachmentRegistry.RETRIEVER_ITEM)) {
+			if (attachment != null && attachment instanceof ConnectionBase && !((ConnectionBase) attachment).canSend()) {
 				continue;
 			}
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoBase.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoBase.java
@@ -54,6 +54,21 @@ public abstract class ServoBase extends ConnectionBase {
 	}
 
 	@Override
+	public boolean isServo() {
+		return true;
+	}
+
+	@Override
+	public boolean isFilter() {
+		return false;
+	}
+
+	@Override
+	public boolean canSend() {
+		return true;
+	}
+
+	@Override
 	public String getName() {
 
 		return "item.thermaldynamics.servo." + type + ".name";

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoFluid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoFluid.java
@@ -9,6 +9,7 @@ import cofh.thermaldynamics.duct.tiles.DuctToken;
 import cofh.thermaldynamics.duct.tiles.TileGrid;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -20,7 +21,7 @@ public class ServoFluid extends ServoBase {
 	public DuctUnitFluid fluidDuct;
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.SERVO_FLUID;
 	}

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoItem.java
@@ -63,6 +63,11 @@ public class ServoItem extends ServoBase implements IItemHandler {
 		itemDuct = tile.getDuct(DuctToken.ITEMS);
 	}
 
+	@Override
+	public String getInfo() {
+		return "tab.thermaldynamics.servoItem";
+	}
+
 	public static Stream<Route<DuctUnitItem, GridItem>> getRoutesWithDestinations(Collection<Route<DuctUnitItem, GridItem>> outputRoutes) {
 
 		return outputRoutes.stream().flatMap(route -> IntStream.range(0, 6).filter(i -> route.endPoint.isOutput(i) && route.endPoint.getConnectionType((byte) i).allowTransfer && route.endPoint.tileCache[i] != null).mapToObj(i -> {

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/servo/ServoItem.java
@@ -21,6 +21,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
@@ -72,7 +73,7 @@ public class ServoItem extends ServoBase implements IItemHandler {
 	}
 
 	@Override
-	public int getId() {
+	public ResourceLocation getId() {
 
 		return AttachmentRegistry.SERVO_ITEM;
 	}

--- a/src/main/java/cofh/thermaldynamics/duct/tiles/TileGrid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/tiles/TileGrid.java
@@ -35,6 +35,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
@@ -562,7 +563,7 @@ public abstract class TileGrid extends TileCore implements IDuctHolder, IPortabl
 			if (attachmentData == null) {
 				attachmentData = new AttachmentData();
 			}
-			int id = tag.getInteger("id");
+			ResourceLocation id = new ResourceLocation(tag.getString("id"));
 			Attachment attachment = AttachmentRegistry.createAttachment(this, side, id);
 			attachmentData.attachments[side] = attachment;
 
@@ -579,7 +580,7 @@ public abstract class TileGrid extends TileCore implements IDuctHolder, IPortabl
 				if (attachment != null) {
 					NBTTagCompound tag = new NBTTagCompound();
 					tag.setInteger("side", i);
-					tag.setInteger("id", (byte) attachment.getId());
+					tag.setString("id", attachment.getId().toString());
 					attachment.writeToNBT(tag);
 					list.appendTag(tag);
 				}
@@ -647,7 +648,7 @@ public abstract class TileGrid extends TileCore implements IDuctHolder, IPortabl
 		payload.addByte(attachmentMask);
 		for (byte i = 0; i < 6; i++) {
 			if (attachmentData.attachments[i] != null) {
-				payload.addByte(attachmentData.attachments[i].getId());
+				payload.addString(attachmentData.attachments[i].getId().toString());
 				attachmentData.attachments[i].addDescriptionToPacket(payload);
 			}
 		}
@@ -686,7 +687,7 @@ public abstract class TileGrid extends TileCore implements IDuctHolder, IPortabl
 				if (attachmentData == null) {
 					attachmentData = new AttachmentData();
 				}
-				int id = payload.getByte();
+				ResourceLocation id = new ResourceLocation(payload.getString());
 				attachmentData.attachments[i] = AttachmentRegistry.createAttachment(this, i, id);
 				attachmentData.attachments[i].getDescriptionFromPacket(payload);
 			} else if (attachmentData != null) {

--- a/src/main/java/cofh/thermaldynamics/duct/tiles/TileGrid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/tiles/TileGrid.java
@@ -563,11 +563,44 @@ public abstract class TileGrid extends TileCore implements IDuctHolder, IPortabl
 			if (attachmentData == null) {
 				attachmentData = new AttachmentData();
 			}
-			ResourceLocation id = new ResourceLocation(tag.getString("id"));
-			Attachment attachment = AttachmentRegistry.createAttachment(this, side, id);
-			attachmentData.attachments[side] = attachment;
-
-			attachment.readFromNBT(tag);
+			Attachment attachment = null;
+			if (tag.hasKey("id", Constants.NBT.TAG_INT)) {
+				switch (tag.getInteger("id")) {
+					case 0:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.FACADE);
+						break;
+					case 1:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.SERVO_FLUID);
+						break;
+					case 2:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.SERVO_ITEM);
+						break;
+					case 3:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.FILTER_FLUID);
+						break;
+					case 4:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.FILTER_ITEM);
+						break;
+					case 5:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.RETRIEVER_FLUID);
+						break;
+					case 6:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.RETRIEVER_ITEM);
+						break;
+					case 7:
+						attachment = AttachmentRegistry.createAttachment(this, side, AttachmentRegistry.RELAY);
+						break;
+					default:
+						break;
+				}
+			} else {
+				ResourceLocation id = new ResourceLocation(tag.getString("id"));
+				attachment = AttachmentRegistry.createAttachment(this, side, id);
+			}
+			if (attachment != null) {
+				attachmentData.attachments[side] = attachment;
+				attachment.readFromNBT(tag);
+			}
 		}
 	}
 

--- a/src/main/java/cofh/thermaldynamics/gui/client/GuiDuctConnection.java
+++ b/src/main/java/cofh/thermaldynamics/gui/client/GuiDuctConnection.java
@@ -55,22 +55,15 @@ public class GuiDuctConnection extends GuiContainerCore {
 		container = (ContainerDuctConnection) inventorySlots;
 		name = conBase.getName();
 		this.ySize = 204;
-		this.isItemServo = conBase.getId() == AttachmentRegistry.SERVO_ITEM || conBase.getId() == AttachmentRegistry.RETRIEVER_ITEM;
-		this.isAdvItemFilter = (conBase.getId() == AttachmentRegistry.FILTER_ITEM || conBase.getId() == AttachmentRegistry.RETRIEVER_ITEM) && conBase.filter.canAlterFlag(FilterLogic.levelRetainSize);
+		this.isItemServo = conBase.getId().equals(AttachmentRegistry.SERVO_ITEM) || conBase.getId().equals(AttachmentRegistry.RETRIEVER_ITEM);
+		this.isAdvItemFilter = (conBase.getId().equals(AttachmentRegistry.FILTER_ITEM) || conBase.getId().equals(AttachmentRegistry.RETRIEVER_ITEM)) && conBase.filter.canAlterFlag(FilterLogic.levelRetainSize);
 
-		switch (conBase.getId()) {
-			case AttachmentRegistry.SERVO_ITEM:
-				generateInfo("tab.thermaldynamics.servoItem");
-				break;
-			case AttachmentRegistry.FILTER_ITEM:
-				generateInfo("tab.thermaldynamics.filterItem");
-				break;
-			case AttachmentRegistry.RETRIEVER_ITEM:
-				generateInfo("tab.thermaldynamics.retrieverItem");
-				break;
-			default:
-				break;
-		}
+		if (conBase.getId().equals(AttachmentRegistry.SERVO_ITEM))
+			generateInfo("tab.thermaldynamics.servoItem");
+		else if (conBase.getId().equals(AttachmentRegistry.FILTER_ITEM))
+			generateInfo("tab.thermaldynamics.filterItem");
+		else if (conBase.getId().equals(AttachmentRegistry.RETRIEVER_ITEM))
+			generateInfo("tab.thermaldynamics.retrieverItem");
 	}
 
 	@Override

--- a/src/main/java/cofh/thermaldynamics/gui/client/GuiDuctConnection.java
+++ b/src/main/java/cofh/thermaldynamics/gui/client/GuiDuctConnection.java
@@ -55,15 +55,12 @@ public class GuiDuctConnection extends GuiContainerCore {
 		container = (ContainerDuctConnection) inventorySlots;
 		name = conBase.getName();
 		this.ySize = 204;
-		this.isItemServo = conBase.getId().equals(AttachmentRegistry.SERVO_ITEM) || conBase.getId().equals(AttachmentRegistry.RETRIEVER_ITEM);
-		this.isAdvItemFilter = (conBase.getId().equals(AttachmentRegistry.FILTER_ITEM) || conBase.getId().equals(AttachmentRegistry.RETRIEVER_ITEM)) && conBase.filter.canAlterFlag(FilterLogic.levelRetainSize);
+		this.isItemServo = conBase.isServo() && conBase.getFilter().isItem();
+		this.isAdvItemFilter = conBase.allowDuctConnection() && conBase.filter.canAlterFlag(FilterLogic.levelRetainSize);
 
-		if (conBase.getId().equals(AttachmentRegistry.SERVO_ITEM))
-			generateInfo("tab.thermaldynamics.servoItem");
-		else if (conBase.getId().equals(AttachmentRegistry.FILTER_ITEM))
-			generateInfo("tab.thermaldynamics.filterItem");
-		else if (conBase.getId().equals(AttachmentRegistry.RETRIEVER_ITEM))
-			generateInfo("tab.thermaldynamics.retrieverItem");
+		String info = conBase.getInfo();
+		if (info != null)
+			generateInfo(info);
 	}
 
 	@Override


### PR DESCRIPTION
I changed the id system of attachments to be based off ResourceLocation (like TileEntity) instead of byte. This will allow addon creators to create additional attachments.

This should fix CoFH/Feedback#561