### PR TITLE
[1.12] Move canSend() from ConnectionBase to Attachment

### DIFF
--- a/src/main/java/cofh/thermaldynamics/duct/Attachment.java
+++ b/src/main/java/cofh/thermaldynamics/duct/Attachment.java
@@ -51,6 +51,11 @@ public abstract class Attachment {
 
 	public abstract Cuboid6 getCuboid();
 
+	/**
+	 * Whether or not retrievers can pull from the attached inventory
+	 */
+	public abstract boolean canSend();
+
 	public void addCollisionBoxesToList(AxisAlignedBB entityBox, List<AxisAlignedBB> list, Entity entity) {
 
 		Cuboid6 cuboid6 = getCuboid().add(baseTile.getPos());

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/ConnectionBase.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/ConnectionBase.java
@@ -78,11 +78,6 @@ public abstract class ConnectionBase extends Attachment implements IStuffable, I
 	public abstract boolean isFilter();
 
 	/**
-	 * Whether or not retrievers can pull from the attached inventory
-	 */
-	public abstract boolean canSend();
-
-	/**
 	 * Adds an info tab in the gui
 	 */
 	@SideOnly (Side.CLIENT)

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/cover/Cover.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/cover/Cover.java
@@ -79,6 +79,11 @@ public class Cover extends Attachment {
 	}
 
 	@Override
+	public boolean canSend() {
+		return false;
+	}
+
+	@Override
 	public boolean onWrenched() {
 
 		baseTile.removeCover(side);

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/relay/Relay.java
@@ -105,6 +105,11 @@ public class Relay extends Attachment implements IConfigGui, IPortableData {
 		return TileGrid.subSelection[side].copy();
 	}
 
+	@Override
+	public boolean canSend() {
+		return true;
+	}
+
 	@Nonnull
 	@Override
 	public BlockDuct.ConnectionType getNeighborType() {

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverFluid.java
@@ -79,7 +79,7 @@ public class RetrieverFluid extends ServoFluid {
 				}
 
 				Attachment attachment = fluidDuct.parent.getAttachment(side);
-				if (attachment != null && attachment instanceof ConnectionBase && !((ConnectionBase) attachment).canSend()) {
+				if (attachment != null && !attachment.canSend()) {
 					continue;
 				}
 

--- a/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/attachments/retriever/RetrieverItem.java
@@ -97,7 +97,7 @@ public class RetrieverItem extends ServoItem {
 		baseTileHasOtherOutputs = false;
 		for (int i = 0; i < 6; i++) {
 			Attachment attachment = baseTile.getAttachment(side);
-			if ((itemDuct.isOutput(side) || itemDuct.isInput(side)) && (attachment == null || !(attachment instanceof ConnectionBase) || ((ConnectionBase) attachment).canSend())) {
+			if ((itemDuct.isOutput(side) || itemDuct.isInput(side)) && (attachment == null  || attachment.canSend())) {
 				baseTileHasOtherOutputs = true;
 				break;
 			}
@@ -117,7 +117,7 @@ public class RetrieverItem extends ServoItem {
 			int i = route.getLastSide();
 
 			Attachment attachment = endPoint.parent.getAttachment(i);
-			if (attachment != null && attachment instanceof ConnectionBase && !((ConnectionBase) attachment).canSend()) {
+			if (attachment != null && !attachment.canSend()) {
 				continue;
 			}
 


### PR DESCRIPTION
This removes three instanceof checks, and it will also help with my own plugin.