### PR TITLE
Re-add Warp Itemducts, Luxducts and introducing Omniducts

### DIFF
--- a/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
+++ b/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
@@ -566,13 +566,13 @@ public class BlockDuct extends BlockTDBase implements IBlockAppearance, IConfigG
 		GameRegistry.registerTileEntity(TileDuctItem.EnergyFast.Transparent.class, "thermaldynamics:duct_item_energy_fast_transparent");
 		GameRegistry.registerTileEntity(TileDuctItem.EnergyFast.Opaque.class, "thermaldynamics:duct_item_energy_fast_opaque");
 
-		//		GameRegistry.registerTileEntity(TileDuctItem.Warp.Transparent.class, "thermaldynamics:duct_item_warp.transparent");
-		//		GameRegistry.registerTileEntity(TileDuctItem.Warp.Opaque.class, "thermaldynamics:duct_item_warp.opaque");
-		//		GameRegistry.registerTileEntity(TileDuctOmni.Transparent.class, "thermaldynamics:duct_item_ender.transparent");
-		//	    GameRegistry.registerTileEntity(TileDuctOmni.Opaque.class, "thermaldynamics:duct_item_ender.opaque");
+		GameRegistry.registerTileEntity(TileDuctItem.Warp.Transparent.class, "thermaldynamics:duct_item_warp.transparent");
+		GameRegistry.registerTileEntity(TileDuctItem.Warp.Opaque.class, "thermaldynamics:duct_item_warp.opaque");
+		GameRegistry.registerTileEntity(TileDuctOmni.Transparent.class, "thermaldynamics:duct_item_ender.transparent");
+		GameRegistry.registerTileEntity(TileDuctOmni.Opaque.class, "thermaldynamics:duct_item_ender.opaque");
 
 		GameRegistry.registerTileEntity(TileStructuralDuct.class, "thermaldynamics:duct_structure");
-		//      GameRegistry.registerTileEntity(TileDuctLight.class, "thermaldynamics:duct_structure_light");
+		GameRegistry.registerTileEntity(TileDuctLight.class, "thermaldynamics:duct_structure_light");
 
 		GameRegistry.registerTileEntity(TileTransportDuct.class, "thermaldynamics:duct_transport_basic");
 		GameRegistry.registerTileEntity(TileTransportDuct.LongRange.class, "thermaldynamics:duct_transport_long_range");

--- a/src/main/java/cofh/thermaldynamics/block/ItemBlockDuct.java
+++ b/src/main/java/cofh/thermaldynamics/block/ItemBlockDuct.java
@@ -160,6 +160,14 @@ public class ItemBlockDuct extends ItemBlockCore {
 					tooltip.add(StringHelper.localize("info.thermaldynamics.duct.itemEnergy"));
 					tooltip.add(StringHelper.localize("info.thermaldynamics.transfer") + ": " + StringHelper.YELLOW + TileDuctItem.NODE_TRANSFER + StringHelper.LIGHT_GRAY + " RF/t.");
 					tooltip.add(StringHelper.getInfoText("tile.thermaldynamics.duct.itemFast.info"));
+				} else if (duct.type == 4) {
+					tooltip.add(StringHelper.localize("info.thermaldynamics.duct.itemFluidEnergy"));
+					tooltip.add(StringHelper.localize("info.thermaldynamics.transfer") + ": " + StringHelper.YELLOW + TileDuctItem.NODE_TRANSFER + StringHelper.LIGHT_GRAY + " RF/t.");
+					tooltip.add(StringHelper.getInfoText("tile.thermaldynamics.duct.fluidHardened.info"));
+				} else if (duct.type == 5) {
+					tooltip.add(StringHelper.localize("info.thermaldynamics.duct.itemEnergy"));
+					tooltip.add(StringHelper.localize("info.thermaldynamics.transfer") + ": " + StringHelper.YELLOW + TileDuctItem.NODE_TRANSFER + StringHelper.LIGHT_GRAY + " RF/t.");
+					tooltip.add(StringHelper.getInfoText("tile.thermaldynamics.duct.itemEnder.info"));
 				}
 				if (stack.hasTagCompound()) {
 					byte pathWeight = stack.getTagCompound().getByte(DuctItem.PATHWEIGHT_NBT);

--- a/src/main/java/cofh/thermaldynamics/duct/TDDucts.java
+++ b/src/main/java/cofh/thermaldynamics/duct/TDDucts.java
@@ -170,7 +170,7 @@ public class TDDucts {
 		addItemDucts();
 		addSupportDucts();
 		addTransportDucts();
-		// addEnderDucts();
+		addEnderDucts();
 	}
 
 	static void addEnergyDucts() {
@@ -238,14 +238,6 @@ public class TDDucts {
 		itemEnergyFast = addDuctItem(OFFSET_ITEM + 6, false, 1, 3, "itemEnergyFast", Type.ITEM, (duct, worldObj) -> new TileDuctItem.EnergyFast.Transparent(), "tin_signalum", "tin", GLOWSTONE_STILL, 80, null, null, 0);
 		itemEnergyFastOpaque = addDuctItem(OFFSET_ITEM + 7, true, 1, 3, "itemEnergyFast", Type.ITEM, (duct, worldObj) -> new TileDuctItem.EnergyFast.Opaque(), "tin_alt_signalum", "tin", null, 0, null, null, 0);
 
-		//		TODO: Readd Omni/Warp Ducts
-		//		itemEnder = addDuctItem(OFFSET_ITEM + 4, false, 0, 2, "itemEnder", Type.ITEM, (duct, worldObj) -> new TileDuctItem.Warp.Transparent(), "enderium", "enderium", null, 48, null, null, 0);
-		//		itemEnderOpaque = addDuctItem(OFFSET_ITEM + 5, true, 0, 2, "itemEnder", Type.ITEM, (duct, worldObj) -> new TileDuctItem.Warp.Opaque(), "enderium", "enderium", null, 48, null, null, 0);
-
-		//		TODO: Readd Omni/Warp Ducts
-		//		itemOmni = addDuctItem(OFFSET_ITEM + 8, false, 0, 0, "itemOmni", Type.ITEM, (duct, worldObj) -> new TileDuctOmni.Transparent(), "enderium", "enderium", null, 48, "enderium_trans_large", null, 0);
-		//		itemOmniOpaque = addDuctItem(OFFSET_ITEM + 9, true, 0, 0, "itemOmni", Type.ITEM, (duct, worldObj) -> new TileDuctOmni.Opaque(), "enderium", "enderium", null, 48, "enderium_large", null, 0);
-
 		itemFast.setRarity(1);
 		itemFastOpaque.setRarity(1);
 
@@ -254,16 +246,20 @@ public class TDDucts {
 
 		itemEnergyFast.setRarity(1);
 		itemEnergyFastOpaque.setRarity(1);
-
-		//		TODO: Readd Omni/Warp Ducts
-		//		itemOmni.setRarity(2);
-		//		itemOmniOpaque.setRarity(2);
 	}
 
 	static void addEnderDucts() {
+		itemOmni = addDuctItem(OFFSET_ENDER + 0, false, 0, 4, "itemOmni", Type.ITEM, (duct, worldObj) -> new TileDuctOmni.Transparent(), "enderium", "enderium", null, 48, "enderium_trans_large", null, 0);
+		itemOmniOpaque = addDuctItem(OFFSET_ENDER + 1, true, 0, 4, "itemOmni", Type.ITEM, (duct, worldObj) -> new TileDuctOmni.Opaque(), "enderium", "enderium", null, 48, "enderium_large", null, 0);
 
-		ender = addDuctItem(OFFSET_ENDER + 0, false, 1, 0, "itemBasic", Type.ITEM, (duct, worldObj) -> new TileDuctItem.Basic.Transparent(), "tin", "tin", null, 0, null, null, 0);
-		enderOpaque = addDuctItem(OFFSET_ENDER + 1, true, 1, 0, "itemBasic", Type.ITEM, (duct, worldObj) -> new TileDuctItem.Basic.Opaque(), "tin", "tin", null, 0, null, null, 0);
+		itemOmni.setRarity(2);
+		itemOmniOpaque.setRarity(2);
+
+		ender = addDuctItem(OFFSET_ENDER + 2, false, 0, 5, "itemEnder", Type.ITEM, (duct, worldObj) -> new TileDuctItem.Warp.Transparent(), "enderium", "enderium", null, 48, null, null, 0);
+		enderOpaque = addDuctItem(OFFSET_ENDER + 3, true, 0, 5, "itemEnder", Type.ITEM, (duct, worldObj) -> new TileDuctItem.Warp.Opaque(), "enderium", "enderium", null, 48, null, null, 0);
+
+		ender.setRarity(2);
+		enderOpaque.setRarity(2);
 	}
 
 	static void addTransportDucts() {
@@ -282,8 +278,7 @@ public class TDDucts {
 	static void addSupportDucts() {
 
 		structure = addDuct(OFFSET_STRUCTURE, true, 1, -1, "structure", Type.STRUCTURAL, STRUCTURAL, "structure", null, null, 0, null, null, 0);
-
-		// lightDuct = registerDuct(new DuctLight(OFFSET_STRUCTURE + 1, 0, "structureLight", Type.STRUCTURAL, (duct, worldObj) -> new TileDuctLight(), "lumium", "lumium", null, 0));
+		lightDuct = registerDuct(new DuctLight(OFFSET_STRUCTURE + 1, 0, "structureLight", Type.STRUCTURAL, (duct, worldObj) -> new TileDuctLight(), "lumium", "lumium", null, 0));
 	}
 
 }

--- a/src/main/java/cofh/thermaldynamics/duct/item/DuctUnitItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/item/DuctUnitItem.java
@@ -56,15 +56,15 @@ public class DuctUnitItem extends DuctUnit<DuctUnitItem, GridItem, DuctUnitItem.
 	public final static byte MAX_TICKS_EXISTED_BEFORE_DUMP = 10;
 	public static final int MAX_CENTER_LINE = 10;
 	// Type Helper Arrays
-	static int[] _DUCT_LEN = { 40, 10, 40, 10 };
-	static int[] _DUCT_HALF_LEN = { _DUCT_LEN[0] / 2, _DUCT_LEN[1] / 2, _DUCT_LEN[2] / 2, _DUCT_LEN[3] / 2 };
-	static float[] _DUCT_TICK_LEN = { 1F / _DUCT_LEN[0], 1F / _DUCT_LEN[1], 1F / _DUCT_LEN[2], 1F / _DUCT_LEN[3] };
-	static float[][][] _SIDE_MODS = new float[4][6][3];
+	static int[] _DUCT_LEN = { 40, 10, 40, 10, 40, 40 };
+	static int[] _DUCT_HALF_LEN = { _DUCT_LEN[0] / 2, _DUCT_LEN[1] / 2, _DUCT_LEN[2] / 2, _DUCT_LEN[3] / 2, _DUCT_LEN[4] / 2, _DUCT_LEN[5] / 2 };
+	static float[] _DUCT_TICK_LEN = { 1F / _DUCT_LEN[0], 1F / _DUCT_LEN[1], 1F / _DUCT_LEN[2], 1F / _DUCT_LEN[3], 1F / _DUCT_LEN[4], 1F / _DUCT_LEN[5] };
+	static float[][][] _SIDE_MODS = new float[6][6][3];
 	static int INSERT_SIZE = 16;
 	static boolean searching = false;
 
 	static {
-		for (int i = 0; i < 4; i++) {
+		for (int i = 0; i < 6; i++) {
 			float j = _DUCT_TICK_LEN[i];
 			_SIDE_MODS[i][0] = new float[] { 0, -j, 0 };
 			_SIDE_MODS[i][1] = new float[] { 0, j, 0 };

--- a/src/main/java/cofh/thermaldynamics/duct/item/DuctUnitItemWarp.java
+++ b/src/main/java/cofh/thermaldynamics/duct/item/DuctUnitItemWarp.java
@@ -124,7 +124,7 @@ public class DuctUnitItemWarp extends DuctUnitItem {
 					return;
 				}
 			} else if (duct.isOutput(travelingItem.direction)) {
-				travelingItem.stack.setCount(duct.insertIntoInventory(travelingItem.stack, travelingItem.direction));
+				travelingItem.stack.setCount(duct.insertIntoInventory(travelingItem.stack.copy(), travelingItem.direction));
 
 				if (travelingItem.stack.getCount() > 0) {
 					travelingItem.reRoute = true;

--- a/src/main/java/cofh/thermaldynamics/duct/light/DuctUnitLight.java
+++ b/src/main/java/cofh/thermaldynamics/duct/light/DuctUnitLight.java
@@ -6,6 +6,7 @@ import cofh.thermaldynamics.duct.Attachment;
 import cofh.thermaldynamics.duct.Duct;
 import cofh.thermaldynamics.duct.tiles.DuctToken;
 import cofh.thermaldynamics.duct.tiles.DuctUnit;
+import cofh.thermaldynamics.duct.tiles.IDuctHolder;
 import cofh.thermaldynamics.duct.tiles.TileGrid;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.EntityLivingBase;
@@ -111,9 +112,9 @@ public class DuctUnitLight extends DuctUnit<DuctUnitLight, GridLight, Void> {
 	}
 
 	@Override
-	public void onNeighborBlockChange() {
+	public void updateAllSides(TileEntity[] tiles, IDuctHolder[] holders) {
 
-		super.onNeighborBlockChange();
+		super.updateAllSides(tiles, holders);
 
 		if (ServerHelper.isClientWorld(world())) {
 			return;

--- a/src/main/java/cofh/thermaldynamics/duct/light/GridLight.java
+++ b/src/main/java/cofh/thermaldynamics/duct/light/GridLight.java
@@ -57,45 +57,13 @@ public class GridLight extends MultiBlockGrid<DuctUnitLight> {
 
 		super.tickGrid();
 
-		// TODO: Fix
-		RedstoneControl rs = null;
+		boolean shouldBeLit = false;
 
-		if (upToDate && worldGrid.worldObj.getTotalWorldTime() % 160 != 0) {
-			if (rs != null) {
-				for (int i = 0; i < 16; i++) {
-					if (rs.nextRedstoneLevel[i] != -128) {
-						upToDate = false;
-					}
-				}
-			}
-			return;
-		}
-
-		if (rs != null) {
-			for (int i = 0; i < 16; i++) {
-				if (rs.nextRedstoneLevel[i] == -128) {
-					upToDate = false;
-				}
-			}
-		} else {
-			upToDate = true;
-		}
-
-		boolean shouldBeLit;
-
-		if (rs != null) {
-			shouldBeLit = rs.shouldEmitLight();
-		} else {
-			shouldBeLit = false;
-		}
-
-		if (!shouldBeLit) {
-			for (Object object : Iterables.concat(nodeSet, idleSet)) {
-				DuctUnitLight lamp = (DuctUnitLight) object;
-				if (lamp.lit) {
-					shouldBeLit = true;
-					break;
-				}
+		for (Object object : Iterables.concat(nodeSet, idleSet)) {
+			DuctUnitLight lamp = (DuctUnitLight) object;
+			if (lamp.lit) {
+				shouldBeLit = true;
+				break;
 			}
 		}
 
@@ -106,7 +74,6 @@ public class GridLight extends MultiBlockGrid<DuctUnitLight> {
 
 	boolean lit = false;
 
-	@SuppressWarnings ("SuspiciousMethodCalls")
 	public void setLight(boolean lit) {
 
 		this.lit = lit;

--- a/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctItem.java
@@ -12,8 +12,6 @@ import cofh.thermaldynamics.duct.item.DuctUnitItemWarp;
 
 public abstract class TileDuctItem extends TileGridStructureBase {
 
-	public static final int NODE_TRANSFER = 4000;
-
 	public TileDuctItem(Duct duct) {
 
 		addDuctUnits(DuctToken.ITEMS, new DuctUnitItem(this, duct));
@@ -78,7 +76,7 @@ public abstract class TileDuctItem extends TileGridStructureBase {
 		public Energy(Duct duct) {
 
 			super(duct);
-			addDuctUnits(DuctToken.ENERGY, new DuctUnitEnergy(this, duct, NODE_TRANSFER, NODE_TRANSFER * 5));
+			addDuctUnits(DuctToken.ENERGY, new DuctUnitEnergy(this, duct, GridEnergy.XFER[1], GridEnergy.XFER[1] * 5));
 		}
 
 		public static class Transparent extends Energy {
@@ -103,7 +101,7 @@ public abstract class TileDuctItem extends TileGridStructureBase {
 		public EnergyFast(Duct duct) {
 
 			super(duct);
-			addDuctUnits(DuctToken.ENERGY, new DuctUnitEnergy(this, duct, NODE_TRANSFER, NODE_TRANSFER * 5));
+			addDuctUnits(DuctToken.ENERGY, new DuctUnitEnergy(this, duct, GridEnergy.XFER[1], GridEnergy.XFER[1] * 5));
 		}
 
 		public static class Transparent extends EnergyFast {

--- a/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctItem.java
@@ -2,9 +2,13 @@ package cofh.thermaldynamics.duct.tiles;
 
 import cofh.redstoneflux.api.IEnergyReceiver;
 import cofh.thermaldynamics.duct.Duct;
+import cofh.thermaldynamics.duct.DuctItem;
 import cofh.thermaldynamics.duct.TDDucts;
 import cofh.thermaldynamics.duct.energy.DuctUnitEnergy;
+import cofh.thermaldynamics.duct.energy.DuctUnitEnergyStorage;
+import cofh.thermaldynamics.duct.energy.GridEnergy;
 import cofh.thermaldynamics.duct.item.DuctUnitItem;
+import cofh.thermaldynamics.duct.item.DuctUnitItemWarp;
 
 public abstract class TileDuctItem extends TileGridStructureBase {
 
@@ -119,36 +123,36 @@ public abstract class TileDuctItem extends TileGridStructureBase {
 		}
 	}
 
-	//	public static class Warp extends TileDuctItem implements IEnergyReceiver {
-	//
-	//		public Warp(DuctItem duct) {
-	//
-	//			DuctUnitEnergyStorage energyStorage = new DuctUnitEnergyStorage(this, duct, 400, 1000) {
-	//
-	//				@Override
-	//				public boolean canConnectToOtherDuct(DuctUnit<DuctUnitEnergy, GridEnergy, IEnergyReceiver> adjDuct, byte side, byte oppositeSide) {
-	//
-	//					return super.canConnectToOtherDuct(adjDuct, side, oppositeSide);
-	//				}
-	//			};
-	//			addDuctUnits(DuctToken.ENERGY, energyStorage);
-	//			addDuctUnits(DuctToken.ITEMS, new DuctUnitItemWarp(this, duct, energyStorage));
-	//		}
-	//
-	//		public static class Transparent extends Warp {
-	//
-	//			public Transparent() {
-	//
-	//				super(TDDucts.itemEnder);
-	//			}
-	//		}
-	//
-	//		public static class Opaque extends Warp {
-	//
-	//			public Opaque() {
-	//
-	//				super(TDDucts.itemEnderOpaque);
-	//			}
-	//		}
-	//	}
+	public static class Warp extends TileDuctItem implements IEnergyReceiver {
+
+		public Warp(DuctItem duct) {
+			super(duct);
+			DuctUnitEnergyStorage energyStorage = new DuctUnitEnergyStorage(this, duct, 400, 1000) {
+
+				@Override
+				public boolean canConnectToOtherDuct(DuctUnit<DuctUnitEnergy, GridEnergy, IEnergyReceiver> adjDuct, byte side, byte oppositeSide) {
+
+					return super.canConnectToOtherDuct(adjDuct, side, oppositeSide);
+				}
+			};
+			addDuctUnits(DuctToken.ENERGY, energyStorage);
+			addDuctUnits(DuctToken.ITEMS, new DuctUnitItemWarp(this, duct, energyStorage));
+		}
+
+		public static class Transparent extends Warp {
+
+			public Transparent() {
+
+				super(TDDucts.ender);
+			}
+		}
+
+		public static class Opaque extends Warp {
+
+			public Opaque() {
+
+				super(TDDucts.enderOpaque);
+			}
+		}
+	}
 }

--- a/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctItem.java
+++ b/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctItem.java
@@ -2,9 +2,13 @@ package cofh.thermaldynamics.duct.tiles;
 
 import cofh.redstoneflux.api.IEnergyReceiver;
 import cofh.thermaldynamics.duct.Duct;
+import cofh.thermaldynamics.duct.DuctItem;
 import cofh.thermaldynamics.duct.TDDucts;
 import cofh.thermaldynamics.duct.energy.DuctUnitEnergy;
+import cofh.thermaldynamics.duct.energy.DuctUnitEnergyStorage;
+import cofh.thermaldynamics.duct.energy.GridEnergy;
 import cofh.thermaldynamics.duct.item.DuctUnitItem;
+import cofh.thermaldynamics.duct.item.DuctUnitItemWarp;
 
 public abstract class TileDuctItem extends TileGridStructureBase {
 
@@ -119,36 +123,38 @@ public abstract class TileDuctItem extends TileGridStructureBase {
 		}
 	}
 
-	//	public static class Warp extends TileDuctItem implements IEnergyReceiver {
-	//
-	//		public Warp(DuctItem duct) {
-	//
-	//			DuctUnitEnergyStorage energyStorage = new DuctUnitEnergyStorage(this, duct, 400, 1000) {
-	//
-	//				@Override
-	//				public boolean canConnectToOtherDuct(DuctUnit<DuctUnitEnergy, GridEnergy, IEnergyReceiver> adjDuct, byte side, byte oppositeSide) {
-	//
-	//					return super.canConnectToOtherDuct(adjDuct, side, oppositeSide);
-	//				}
-	//			};
-	//			addDuctUnits(DuctToken.ENERGY, energyStorage);
-	//			addDuctUnits(DuctToken.ITEMS, new DuctUnitItemWarp(this, duct, energyStorage));
-	//		}
-	//
-	//		public static class Transparent extends Warp {
-	//
-	//			public Transparent() {
-	//
-	//				super(TDDucts.itemEnder);
-	//			}
-	//		}
-	//
-	//		public static class Opaque extends Warp {
-	//
-	//			public Opaque() {
-	//
-	//				super(TDDucts.itemEnderOpaque);
-	//			}
-	//		}
-	//	}
+	public static class Warp extends TileDuctItem implements IEnergyReceiver {
+
+		public Warp(DuctItem duct) {
+			super(duct);
+
+			DuctUnitEnergyStorage energyStorage = new DuctUnitEnergyStorage(this, duct, 400, 1000) {
+
+				@Override
+				public boolean canConnectToOtherDuct(DuctUnit<DuctUnitEnergy, GridEnergy, IEnergyReceiver> adjDuct, byte side, byte oppositeSide) {
+
+					return super.canConnectToOtherDuct(adjDuct, side, oppositeSide);
+				}
+			};
+			addDuctUnits(DuctToken.ENERGY, energyStorage);
+			addDuctUnits(DuctToken.ITEMS, new DuctUnitItemWarp(this, duct, energyStorage));
+		}
+
+		public static class Transparent extends Warp {
+
+			public Transparent() {
+
+				super(TDDucts.ender);
+			}
+		}
+
+		public static class Opaque extends Warp {
+
+			public Opaque() {
+
+				super(TDDucts.enderOpaque);
+			}
+		}
+	}
+
 }

--- a/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctLight.java
+++ b/src/main/java/cofh/thermaldynamics/duct/tiles/TileDuctLight.java
@@ -1,20 +1,17 @@
 package cofh.thermaldynamics.duct.tiles;
 
-import cofh.thermaldynamics.duct.Duct;
 import cofh.thermaldynamics.duct.TDDucts;
 import cofh.thermaldynamics.duct.light.DuctUnitLight;
 
-public class TileDuctLight extends TileGridSingle {
+public class TileDuctLight extends TileGridStructureBase {
 
 	public TileDuctLight() {
-
-		super(DuctToken.LIGHT, TDDucts.lightDuct);
+		addDuctUnits(DuctToken.LIGHT, new DuctUnitLight(this, TDDucts.lightDuct));
 	}
 
 	@Override
-	protected DuctUnit createDuctUnit(DuctToken token, Duct ductType) {
-
-		return new DuctUnitLight(this, ductType);
+	protected DuctToken getPrimaryDuctToken() {
+		return DuctToken.LIGHT;
 	}
 
 }

--- a/src/main/java/cofh/thermaldynamics/proxy/ProxyClient.java
+++ b/src/main/java/cofh/thermaldynamics/proxy/ProxyClient.java
@@ -8,10 +8,9 @@ import cofh.thermaldynamics.duct.entity.EntityTransport;
 import cofh.thermaldynamics.duct.entity.RenderTransport;
 import cofh.thermaldynamics.duct.tiles.TileDuctFluid;
 import cofh.thermaldynamics.duct.tiles.TileDuctItem;
+import cofh.thermaldynamics.duct.tiles.TileDuctOmni;
 import cofh.thermaldynamics.init.TDItems;
-import cofh.thermaldynamics.render.RenderDuct;
-import cofh.thermaldynamics.render.RenderDuctFluids;
-import cofh.thermaldynamics.render.RenderDuctItems;
+import cofh.thermaldynamics.render.*;
 import cofh.thermaldynamics.render.item.RenderItemCover;
 import cofh.thermaldynamics.util.CoverBlacklistCommand;
 import cofh.thermaldynamics.util.TickHandlerClient;
@@ -58,8 +57,8 @@ public class ProxyClient extends Proxy {
 		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctItem.Fast.Transparent.class, RenderDuctItems.INSTANCE);
 		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctItem.Energy.Transparent.class, RenderDuctItems.INSTANCE);
 		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctItem.EnergyFast.Transparent.class, RenderDuctItems.INSTANCE);
-		//		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctItem.Warp.Transparent.class, RenderDuctItemsEnder.INSTANCE);
-		//		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctOmni.Transparent.class, RenderDuctOmni.INSTANCE);
+		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctItem.Warp.Transparent.class, RenderDuctItemsEnder.INSTANCE);
+		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctOmni.Transparent.class, RenderDuctOmni.INSTANCE);
 
 		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctFluid.Basic.Transparent.class, RenderDuctFluids.INSTANCE);
 		ClientRegistry.bindTileEntitySpecialRenderer(TileDuctFluid.Super.Transparent.class, RenderDuctFluids.INSTANCE);

--- a/src/main/java/cofh/thermaldynamics/util/TDCrafting.java
+++ b/src/main/java/cofh/thermaldynamics/util/TDCrafting.java
@@ -105,11 +105,19 @@ public class TDCrafting {
 		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemEnergyFast.itemStack, 3), TDDucts.itemFast.itemStack, TDDucts.itemFast.itemStack, TDDucts.itemFast.itemStack, "ingotSignalum", "ingotElectrum");
 		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemEnergyFastOpaque.itemStack, 3), TDDucts.itemFastOpaque.itemStack, TDDucts.itemFastOpaque.itemStack, TDDucts.itemFastOpaque.itemStack, "ingotSignalum", "ingotElectrum");
 
-		//		TODO: Readd Omni/Warp Ducts
-		//		GameRegistry.addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmni.itemStack, 2), TDDucts.itemBasic.itemStack, TDDucts.itemBasic.itemStack, "nuggetEnderium", "nuggetEnderium", "nuggetEnderium"));
-		//		GameRegistry.addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmniOpaque.itemStack, 2), TDDucts.itemBasicOpaque.itemStack, TDDucts.itemBasicOpaque.itemStack, "nuggetEnderium", "nuggetEnderium", "nuggetEnderium"));
-		//		GameRegistry.addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmni.itemStack, 6), TDDucts.itemBasic.itemStack, TDDucts.itemBasic.itemStack, TDDucts.itemBasic.itemStack, TDDucts.itemBasic.itemStack, TDDucts.itemBasic.itemStack, TDDucts.itemBasic.itemStack, "ingotEnderium"));
-		//		GameRegistry.addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmniOpaque.itemStack, 6), TDDucts.itemBasicOpaque.itemStack, TDDucts.itemBasicOpaque.itemStack, TDDucts.itemBasicOpaque.itemStack, TDDucts.itemBasicOpaque.itemStack, TDDucts.itemBasicOpaque.itemStack, TDDucts.itemBasicOpaque.itemStack, "ingotEnderium"));
+		// Warp Itemduct
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.ender.itemStack, 2), TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, "nuggetEnderium", "nuggetEnderium", "nuggetEnderium");
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.enderOpaque.itemStack, 2), TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, "nuggetEnderium", "nuggetEnderium", "nuggetEnderium");
+
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.ender.itemStack, 6), TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, "ingotEnderium");
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.enderOpaque.itemStack, 6), TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, "ingotEnderium");
+
+		// Omniduct
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmni.itemStack, 2), TDDucts.itemEnergy.itemStack, TDDucts.fluidEnergy.itemStack, "nuggetEnderium", "nuggetEnderium", "nuggetEnderium");
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmniOpaque.itemStack, 2), TDDucts.itemEnergyOpaque.itemStack, TDDucts.fluidEnergyOpaque.itemStack, "nuggetEnderium", "nuggetEnderium", "nuggetEnderium");
+
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmni.itemStack, 6), TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, TDDucts.itemEnergy.itemStack, TDDucts.fluidEnergy.itemStack, TDDucts.fluidEnergy.itemStack, TDDucts.fluidEnergy.itemStack, "ingotEnderium");
+		addShapelessRecipe(ItemHelper.cloneStack(TDDucts.itemOmniOpaque.itemStack, 6), TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, TDDucts.itemEnergyOpaque.itemStack, TDDucts.fluidEnergyOpaque.itemStack, TDDucts.fluidEnergyOpaque.itemStack, TDDucts.fluidEnergyOpaque.itemStack, "ingotEnderium");
 
 		/* ITEMS - TE Integration */
 		addTransposerFill(800, TDDucts.itemBasic.itemStack, TDDucts.itemFast.itemStack, new FluidStack(fluidGlowstone, 200), false);
@@ -119,9 +127,7 @@ public class TDCrafting {
 
 		/* STRUCTURE */
 		addShapedRecipe(ItemHelper.cloneStack(TDDucts.structure.itemStack, 6), "iIi", 'i', "nuggetIron", 'I', "ingotLead");
-
-		// TODO: Readd.
-		// addShapedRecipe(ItemHelper.cloneStack(TDDucts.lightDuct.itemStack, 6), "LIL", 'L', "ingotLumium", 'I', "ingotLead");
+		addShapedRecipe(ItemHelper.cloneStack(TDDucts.lightDuct.itemStack, 6), "LIL", 'L', "ingotLumium", 'I', "ingotLead");
 
 		/* TRANSPORT */
 		addShapedRecipe(ItemHelper.cloneStack(TDDucts.transportFrame.itemStack, 4), "IGI", "G G", "IGI", 'I', "ingotBronze", 'G', glassHardened);
@@ -137,7 +143,7 @@ public class TDCrafting {
 		}
 
 		/* CONVERSIONS */
-		for (Duct[] duct : new Duct[][] { { TDDucts.itemBasic, TDDucts.itemBasicOpaque }, { TDDucts.itemFast, TDDucts.itemFastOpaque }, { TDDucts.itemEnergy, TDDucts.itemEnergyOpaque }, { TDDucts.itemEnergyFast, TDDucts.itemEnergyFastOpaque }, { TDDucts.fluidHardened, TDDucts.fluidHardenedOpaque }, { TDDucts.fluidEnergy, TDDucts.fluidEnergyOpaque }, { TDDucts.fluidSuper, TDDucts.fluidSuperOpaque } }) {
+		for (Duct[] duct : new Duct[][] { { TDDucts.itemBasic, TDDucts.itemBasicOpaque }, { TDDucts.itemFast, TDDucts.itemFastOpaque }, { TDDucts.itemEnergy, TDDucts.itemEnergyOpaque }, { TDDucts.itemEnergyFast, TDDucts.itemEnergyFastOpaque }, { TDDucts.fluidHardened, TDDucts.fluidHardenedOpaque }, { TDDucts.fluidEnergy, TDDucts.fluidEnergyOpaque }, { TDDucts.fluidSuper, TDDucts.fluidSuperOpaque }, { TDDucts.itemOmni, TDDucts.itemOmniOpaque }, { TDDucts.ender, TDDucts.enderOpaque } }) {
 
 			final ItemStack t = duct[0].itemStack;
 			final ItemStack o = duct[1].itemStack;
@@ -155,7 +161,7 @@ public class TDCrafting {
 		}
 
 		/* DENSE / VACUUM - TE Integration */
-		for (DuctItem duct : new DuctItem[] { TDDucts.itemBasic, TDDucts.itemBasicOpaque, TDDucts.itemFast, TDDucts.itemFastOpaque, TDDucts.itemEnergy, TDDucts.itemEnergyOpaque, TDDucts.itemEnergyFast, TDDucts.itemEnergyFastOpaque }) {
+		for (DuctItem duct : new DuctItem[] { TDDucts.itemBasic, TDDucts.itemBasicOpaque, TDDucts.itemFast, TDDucts.itemFastOpaque, TDDucts.itemEnergy, TDDucts.itemEnergyOpaque, TDDucts.itemEnergyFast, TDDucts.itemEnergyFastOpaque, TDDucts.itemOmni, TDDucts.itemOmniOpaque, TDDucts.ender, TDDucts.enderOpaque }) {
 			addShapelessRecipe(duct.getDenseItemStack(), duct.itemStack, "nuggetLead", "nuggetLead", "nuggetLead");
 			addShapelessRecipe(duct.getVacuumItemStack(), duct.itemStack, "nuggetSilver", "nuggetSilver", "nuggetSilver");
 			//			addShapelessRecipe(duct.itemStack, duct.getDenseItemStack(), "dustCharcoal");

--- a/src/main/resources/assets/thermaldynamics/lang/en_GB.lang
+++ b/src/main/resources/assets/thermaldynamics/lang/en_GB.lang
@@ -3,3 +3,7 @@
 
 tile.thermaldynamics.duct.energySuper.name=Cryo-Stabilised Fluxduct
 tile.thermaldynamics.duct.energySuperEmpty.name=Cryo-Stabilised Fluxduct (Empty)
+
+tile.thermaldynamics.duct.fluidSuper.info=Limitless transfer rate when pressurised.
+
+tile.thermaldynamics.duct.itemEnder.info=Items travel instantly when energised.

--- a/src/main/resources/assets/thermaldynamics/lang/en_US.lang
+++ b/src/main/resources/assets/thermaldynamics/lang/en_US.lang
@@ -16,6 +16,7 @@ info.thermaldynamics.duct.fluid=Transfers Fluids.
 info.thermaldynamics.duct.fluidEnergy=Transfers Fluids and Redstone Flux (RF).
 info.thermaldynamics.duct.item=Transfers Items.
 info.thermaldynamics.duct.itemEnergy=Transfers Items and Redstone Flux (RF).
+info.thermaldynamics.duct.itemFluidEnergy=Transfers Items, Fluids and Redstone Flux (RF).
 info.thermaldynamics.duct.light=Emits light when given a Redstone signal.
 info.thermaldynamics.duct.structure=Provides Structure.
 info.thermaldynamics.duct.transport=Transfers Players. Whoosh.
@@ -169,10 +170,12 @@ tile.thermaldynamics.duct.fluidSuper.name=Super-Laminar Fluiduct
 
 tile.thermaldynamics.duct.itemBasic.name=Itemduct
 tile.thermaldynamics.duct.itemEnder.name=Warp Itemduct
+tile.thermaldynamics.duct.itemEnder.info=Items travel instantly when energized.
 tile.thermaldynamics.duct.itemEnergy.name=Signalum-Plated Itemduct
 tile.thermaldynamics.duct.itemEnergyFast.name=Signalum-Plated Impulse Itemduct
 tile.thermaldynamics.duct.itemFast.info=Items travel more rapidly.
 tile.thermaldynamics.duct.itemFast.name=Impulse Itemduct
+tile.thermaldynamics.duct.itemOmni.name=Omniduct
 
 tile.thermaldynamics.duct.opaque.name=%s (Opaque)
 


### PR DESCRIPTION
![conversation](https://cdn.discordapp.com/attachments/233544641788641280/569218064864903172/unknown.png)

I'm mainly opening this pull request for the Warp Itemducts and Luxducts, but I also saw that Omniducts were a thing in the code so I added them as well.

I changed the recipe of the Warp Itemduct from 6 itemducts + 1 enderium to 6 signalum plated itemducts + 1 enderium. I did this because the Warp Itemducts can transfer 4000 RF/t, just like the signalum plated itemducts.

The recipe for the omniduct is 3 signalum itemducts + 3 signalum fluiducts + enderium ingot. They look like Warp Itemducts so I made the recipe similar to it.