### PR TITLE
Fix ClassCastException

### DIFF
--- a/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
+++ b/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
@@ -149,13 +149,11 @@ public class BlockDuct extends BlockTDBase implements IBlockAppearance, IConfigG
 
 		AxisAlignedBB bb = new AxisAlignedBB(min, min, min, max, max, max);
 		addCollisionBoxToList(pos, entityBox, collidingBoxes, bb);
-		TileGrid theTile;
-		TileEntity theTileEntity = world.getTileEntity(pos);
-		if (theTileEntity instanceof TileGrid) {
-			theTile = (TileGrid) theTileEntity;
-		} else {
+		TileEntity tile = world.getTileEntity(pos);
+		if (!(tile instanceof TileGrid)) {
 			return;
 		}
+		TileGrid theTile = (TileGrid) tile;
 
 		if (theTile != null) {
 			for (byte i = 0; i < 6; i++) {

--- a/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
+++ b/src/main/java/cofh/thermaldynamics/block/BlockDuct.java
@@ -149,7 +149,13 @@ public class BlockDuct extends BlockTDBase implements IBlockAppearance, IConfigG
 
 		AxisAlignedBB bb = new AxisAlignedBB(min, min, min, max, max, max);
 		addCollisionBoxToList(pos, entityBox, collidingBoxes, bb);
-		TileGrid theTile = (TileGrid) world.getTileEntity(pos);
+		TileGrid theTile;
+		TileEntity theTileEntity = world.getTileEntity(pos);
+		if (theTileEntity instanceof TileGrid) {
+			theTile = (TileGrid) theTileEntity;
+		} else {
+			return;
+		}
 
 		if (theTile != null) {
 			for (byte i = 0; i < 6; i++) {


### PR DESCRIPTION
Sometimes the TileEntity is not an instance of TileGrid and this can cause the player to be unable to log in and server log errors such as these:
https://paste.dimdev.org/huyegeguva.mccrash
https://forums.spongepowered.org/t/crash-with-thermal-dynamics-and-ae/29499
https://pastebin.com/fuuaUYCP
https://gist.github.com/tenten8401/3b07031bcf0646a51948906d5ad8e1c3